### PR TITLE
fix!: deprecate passing nil to update_capabilities and do not force merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ And then you need to configure a mapping to visually select accordingly to your 
 local nvim_lsp = require('lspconfig')
 local lsp_selection_range = require('lsp-selection-range')
 
--- Generate the default Neovim LSP capabilities
-local capabilities = vim.lsp.protocol.make_client_capabilities()
--- Update the default capabilities
-capabilities = lps_selection_range.update_capabilities(capabilities)
+-- Update existing capabilities
+capabilities = lsp_selection_range.update_capabilities(capabilities)
+
+-- If you don't already have custom capabilities you can simply do
+local capabilities = lsp_selection_range.update_capabilities({})
 
 local on_attach = function(client, bufnr)
   local bmap = function(mode, lhs, rhs, options)

--- a/lua/lsp-selection-range/init.lua
+++ b/lua/lsp-selection-range/init.lua
@@ -71,10 +71,13 @@ M.get_client = client_module.select
 ---@see vim.lsp.protocol.make_client_capabilities()
 function M.update_capabilities(capabilities)
   vim.validate({ capabilities = { capabilities, 'table', true } })
+  if not capabilities then
+    vim.notify_once('lsp-selection-range.update_capabilities: Passing nil is deprecated.', vim.log.levels.WARN)
+  end
   capabilities = capabilities or vim.lsp.protocol.make_client_capabilities()
 
-  capabilities.textDocument = vim.tbl_extend('force', capabilities.textDocument or {}, {
-    selectionRange = { dynamicRegistration = false },
+  capabilities.textDocument = vim.tbl_deep_extend('keep', capabilities.textDocument or {}, {
+    selectionRange = { dynamicRegistration = false }
   })
 
   return capabilities


### PR DESCRIPTION
Since [nvim-lspconfig#1889](https://github.com/neovim/nvim-lspconfig/pull/1889), it is no longer necessary to call vim.lsp.make_client_capabilities(). Instead, it is enough to pass the capabilities to override.